### PR TITLE
Simplify registration forms

### DIFF
--- a/src/components/registration/AttendeeForm.tsx
+++ b/src/components/registration/AttendeeForm.tsx
@@ -1,39 +1,27 @@
 import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
-import { Calendar } from "@/components/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { CalendarIcon, Plus, Trash2, Users } from "lucide-react";
-import { format } from "date-fns";
-import { cn } from "@/lib/utils";
+import { Plus, Trash2, Users } from "lucide-react";
 
 interface Department {
   code: string;
   name: string;
 }
 
-const attendeeSchema = z.object({
-  full_name: z.string().min(2, "Full name is required"),
-  email: z.string().email().optional().or(z.literal("")),
-  phone: z.string().optional(),
-  birthdate: z.date().optional(),
-  department_code: z.string({
-    required_error: "Department is required",
-  }),
-});
-
-type AttendeeFormData = z.infer<typeof attendeeSchema>;
+interface AttendeeFormData {
+  full_name: string;
+  email?: string;
+  phone?: string;
+  age_years?: number;
+  department_code: string;
+}
 
 interface AttendeeFormProps {
   departments: Department[];
   maxAttendees: number;
-  onComplete?: (attendees: (AttendeeFormData & { age_years?: number })[]) => void;
+  onComplete?: (attendees: AttendeeFormData[]) => void;
 }
 
 export const AttendeeForm = ({ departments, maxAttendees, onComplete }: AttendeeFormProps) => {
@@ -42,13 +30,10 @@ export const AttendeeForm = ({ departments, maxAttendees, onComplete }: Attendee
       full_name: "",
       email: "",
       phone: "",
+      age_years: undefined,
       department_code: "",
     }
   ]);
-
-  const form = useForm<AttendeeFormData>({
-    resolver: zodResolver(attendeeSchema),
-  });
 
   const addAttendee = () => {
     if (attendees.length < maxAttendees) {
@@ -56,6 +41,7 @@ export const AttendeeForm = ({ departments, maxAttendees, onComplete }: Attendee
         full_name: "",
         email: "",
         phone: "",
+        age_years: undefined,
         department_code: "",
       }]);
     }
@@ -74,13 +60,7 @@ export const AttendeeForm = ({ departments, maxAttendees, onComplete }: Attendee
   };
 
   const handleSubmit = () => {
-    const processedAttendees = attendees.map(attendee => ({
-      ...attendee,
-      age_years: attendee.birthdate ? 
-        new Date().getFullYear() - attendee.birthdate.getFullYear() : undefined
-    }));
-    
-    onComplete?.(processedAttendees);
+    onComplete?.(attendees);
   };
 
   const isFormValid = attendees.every(attendee => 
@@ -161,37 +141,20 @@ export const AttendeeForm = ({ departments, maxAttendees, onComplete }: Attendee
               </div>
 
               <div>
-                <label className="text-sm font-medium">Birth Date</label>
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      className={cn(
-                        "w-full pl-3 text-left font-normal",
-                        !attendee.birthdate && "text-muted-foreground"
-                      )}
-                    >
-                      {attendee.birthdate ? (
-                        format(attendee.birthdate, "PPP")
-                      ) : (
-                        <span>Pick a date</span>
-                      )}
-                      <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
-                    <Calendar
-                      mode="single"
-                      selected={attendee.birthdate}
-                      onSelect={(date) => updateAttendee(index, "birthdate", date)}
-                      disabled={(date) =>
-                        date > new Date() || date < new Date("1900-01-01")
-                      }
-                      initialFocus
-                      className={cn("p-3 pointer-events-auto")}
-                    />
-                  </PopoverContent>
-                </Popover>
+                <label className="text-sm font-medium">Age</label>
+                <Input
+                  type="number"
+                  min={0}
+                  value={attendee.age_years ?? ""}
+                  onChange={(e) =>
+                    updateAttendee(
+                      index,
+                      "age_years",
+                      e.target.value ? Number(e.target.value) : undefined
+                    )
+                  }
+                  placeholder="Enter age (optional)"
+                />
               </div>
             </div>
           </div>

--- a/src/components/registration/ProfileForm.tsx
+++ b/src/components/registration/ProfileForm.tsx
@@ -1,17 +1,10 @@
-import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
-import { Calendar } from "@/components/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { CalendarIcon } from "lucide-react";
-import { format } from "date-fns";
-import { cn } from "@/lib/utils";
 import { useUpdateProfile, Profile } from "@/hooks/useProfile";
 import { useToast } from "@/hooks/use-toast";
 
@@ -20,12 +13,15 @@ const profileSchema = z.object({
   first_name: z.string().optional(),
   last_name: z.string().optional(),
   phone: z.string().optional(),
-  birthdate: z.date().optional(),
+  age_years: z
+    .preprocess(
+      (v) => (v === "" || v === undefined ? undefined : Number(v)),
+      z.number().int().positive().optional()
+    ),
   korean_name: z.string().optional(),
-  church: z.string().optional(),
   home_church: z.string().optional(),
-  emergency_contact_name: z.string().min(2, "Emergency contact name is required"),
-  emergency_contact_phone: z.string().min(10, "Emergency contact phone is required"),
+  emergency_contact_name: z.string().optional(),
+  emergency_contact_phone: z.string().optional(),
 });
 
 type ProfileFormData = z.infer<typeof profileSchema>;
@@ -46,9 +42,8 @@ export const ProfileForm = ({ profile, onComplete }: ProfileFormProps) => {
       first_name: profile?.first_name || "",
       last_name: profile?.last_name || "",
       phone: profile?.phone || "",
-      birthdate: profile?.birthdate ? new Date(profile.birthdate) : undefined,
+      age_years: profile?.age_years ?? undefined,
       korean_name: profile?.korean_name || "",
-      church: profile?.church || "",
       home_church: profile?.home_church || "",
       emergency_contact_name: profile?.emergency_contact_name || "",
       emergency_contact_phone: profile?.emergency_contact_phone || "",
@@ -60,8 +55,6 @@ export const ProfileForm = ({ profile, onComplete }: ProfileFormProps) => {
       const profileData = {
         ...data,
         full_name: data.full_name, // Ensure full_name is present
-        birthdate: data.birthdate?.toISOString().split('T')[0],
-        age_years: data.birthdate ? new Date().getFullYear() - data.birthdate.getFullYear() : undefined,
       };
 
       await updateProfile.mutateAsync(profileData);
@@ -163,55 +156,21 @@ export const ProfileForm = ({ profile, onComplete }: ProfileFormProps) => {
 
               <FormField
                 control={form.control}
-                name="birthdate"
-                render={({ field }) => (
-                  <FormItem className="flex flex-col">
-                    <FormLabel>Birth Date</FormLabel>
-                    <Popover>
-                      <PopoverTrigger asChild>
-                        <FormControl>
-                          <Button
-                            variant="outline"
-                            className={cn(
-                              "pl-3 text-left font-normal",
-                              !field.value && "text-muted-foreground"
-                            )}
-                          >
-                            {field.value ? (
-                              format(field.value, "PPP")
-                            ) : (
-                              <span>Pick a date</span>
-                            )}
-                            <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                          </Button>
-                        </FormControl>
-                      </PopoverTrigger>
-                      <PopoverContent className="w-auto p-0" align="start">
-                        <Calendar
-                          mode="single"
-                          selected={field.value}
-                          onSelect={field.onChange}
-                          disabled={(date) =>
-                            date > new Date() || date < new Date("1900-01-01")
-                          }
-                          initialFocus
-                          className={cn("p-3 pointer-events-auto")}
-                        />
-                      </PopoverContent>
-                    </Popover>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="church"
+                name="age_years"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Church</FormLabel>
+                    <FormLabel>Age</FormLabel>
                     <FormControl>
-                      <Input {...field} />
+                      <Input
+                        type="number"
+                        min={0}
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value ? Number(e.target.value) : undefined
+                          )
+                        }
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -237,7 +196,7 @@ export const ProfileForm = ({ profile, onComplete }: ProfileFormProps) => {
                 name="emergency_contact_name"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Emergency Contact Name *</FormLabel>
+                    <FormLabel>Emergency Contact Name</FormLabel>
                     <FormControl>
                       <Input {...field} />
                     </FormControl>
@@ -251,7 +210,7 @@ export const ProfileForm = ({ profile, onComplete }: ProfileFormProps) => {
                 name="emergency_contact_phone"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Emergency Contact Phone *</FormLabel>
+                    <FormLabel>Emergency Contact Phone</FormLabel>
                     <FormControl>
                       <Input {...field} />
                     </FormControl>

--- a/src/pages/EventRegistration.tsx
+++ b/src/pages/EventRegistration.tsx
@@ -30,7 +30,6 @@ interface AttendeeData {
   full_name: string;
   email?: string;
   phone?: string;
-  birthdate?: Date;
   department_code: string;
   age_years?: number;
 }
@@ -65,7 +64,7 @@ export default function EventRegistration() {
 
   // Move to room booking if profile is complete
   useEffect(() => {
-    if (currentStep === "profile" && profile?.full_name && profile?.emergency_contact_name) {
+    if (currentStep === "profile" && profile?.full_name) {
       setCurrentStep("room");
     }
   }, [profile, currentStep]);


### PR DESCRIPTION
## Summary
- remove unused church field and make emergency contact optional
- switch profile and attendee forms from birth date to age input
- adjust event registration logic for new attendee data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected lexical declaration in case block)*

------
https://chatgpt.com/codex/tasks/task_e_68a928d4fe8c83238982c3dfe81fa760